### PR TITLE
fix sticky header when not in sub-scrollable container

### DIFF
--- a/dist/reporttable.js
+++ b/dist/reporttable.js
@@ -195,12 +195,11 @@
 
     ReportTable.prototype.moveHeader = function()
     {
-        var headers = $("#regularContainer").find(".reporttable_header");
-        var offset = this.container.offset().top;
+        var headers = this.options.scrollContainer.find("#regularContainer").find(".reporttable_header");
 
-        if(offset < 0) {
-            offset = Math.abs(offset) + this.options.offsetHeaderHeight;
-        } else {
+        offset = $(window).scrollTop() + this.options.offsetHeaderHeight - this.container.offset().top;
+        
+        if (offset < 0) {
             offset = 0;
         }
 


### PR DESCRIPTION
The sticky header currently does not work if the scrollable container is the document. This calculation takes that into account.

Also fixes sticky headers if there are multiple tables per page.